### PR TITLE
Added feature getAvailableGuiders

### DIFF
--- a/guider-2.1.0.dev.js
+++ b/guider-2.1.0.dev.js
@@ -738,6 +738,17 @@
 			_display();
 
 			return _plugin
+		},
+		
+		getAvailableGuiders: function(className){
+			var elements_list = [];
+			var elements = document.getElementsByClassName(className);
+			for(var i=0; i<elements.length; i++) {
+				if(elements[i].id){
+					elements_list.push(elements[i].id);
+				}
+			}
+			return(elements_list);
 		}
 
 	}, function(k, v){ _plugin[k] = v });


### PR DESCRIPTION
This PR allows users to get a list of HTML ids that have a particular css class. 
For example, if you have something like this

``` html
<div>
    <div id="first_div" class="guider">First div</div>
    <div id="second_div" class="not_guider">Second div</div>
   <div id="third_div" class="guider">Third div</div>
</div>
```

Instruction $.guider.getAvailableGuiders('guider'), returns ['first_div', 'third_div'].

In my case, this functionality is useful to redirect correctly to the next guider in a page with elements not always visible.
